### PR TITLE
remove unicode from titles

### DIFF
--- a/gitchangelog.py
+++ b/gitchangelog.py
@@ -162,7 +162,7 @@ class GithubChangelog(object):
 
             # Add the pull request title to our change log.
             changes.append("* #{} - {} - @{}".format(
-                pull.number, pull.title, pull.user.get("login")
+                pull.number, pull.title.encode('ascii', 'ignore'), pull.user.get("login")
             ))
             self.say("Found closed pull request: {}".format(changes[-1]))
 

--- a/gitchangelog.py
+++ b/gitchangelog.py
@@ -2,6 +2,8 @@
 
 """gitchangelog: Generate a change log based on closed pull requests."""
 
+from __future__ import unicode_literals
+
 __version__ = '1.6.0'
 
 import six
@@ -162,7 +164,7 @@ class GithubChangelog(object):
 
             # Add the pull request title to our change log.
             changes.append("* #{} - {} - @{}".format(
-                pull.number, pull.title.encode('ascii', 'ignore'), pull.user.get("login")
+                pull.number, pull.title, pull.user.get("login")
             ))
             self.say("Found closed pull request: {}".format(changes[-1]))
 


### PR DESCRIPTION
I tried running the script against a repo with a PR that contained a unicode char in the title. This change removed the offensive character.
